### PR TITLE
[feature/#43] 배달 완료 처리 구현

### DIFF
--- a/server/src/main/java/circulo/server/domain/delivery/entity/Delivery.java
+++ b/server/src/main/java/circulo/server/domain/delivery/entity/Delivery.java
@@ -47,4 +47,8 @@ public class Delivery extends BaseEntity {
         this.deliveryMan = deliveryMan;
         this.status = DeliveryStatus.IN_PROGRESS;
     }
+
+    public void changeStatus(DeliveryStatus status) {
+        this.status = status;
+    }
 }

--- a/server/src/main/java/circulo/server/domain/delivery/repository/DeliveryRepository.java
+++ b/server/src/main/java/circulo/server/domain/delivery/repository/DeliveryRepository.java
@@ -34,5 +34,8 @@ public interface DeliveryRepository extends JpaRepository<Delivery, Long> {
         AND d.status = :status
     """)
     Optional<Delivery> findByIdAndStatus(@Param("deliveryId") Long deliveryId, @Param("status") DeliveryStatus status);
+
+    Optional<Delivery> findByPackageSubmissionId(Long packageSubmissionId);
+
 }
 

--- a/server/src/main/java/circulo/server/domain/packageSubmission/controller/PackageSubmissionController.java
+++ b/server/src/main/java/circulo/server/domain/packageSubmission/controller/PackageSubmissionController.java
@@ -55,4 +55,15 @@ public class PackageSubmissionController {
 PackageSubmissionResponse.PackageSubmissionAcceptedResponse response = packageSubmissionCommandService.acceptPackageSubmission(userId, packageSubmissionId, packagingRequestId);
         return ApiResponse.onSuccess(response);
     }
+
+    @Operation(
+            summary = "배달 완료 처리 API | by 규리",
+            description = "소상공인이 배달 완료 버튼을 누르면 해당 Packaging Submission을 배달 완료 처리합니다."
+    )
+    @PostMapping("/{packageSubmissionId}/delivered")
+    public ApiResponse<Void> markAsDelivered(@PathVariable Long packageSubmissionId) {
+        packageSubmissionCommandService.markAsDelivered(packageSubmissionId);
+        return ApiResponse.onSuccess(null);
+    }
+
 }

--- a/server/src/main/java/circulo/server/domain/packageSubmission/service/PackageSubmissionCommandService.java
+++ b/server/src/main/java/circulo/server/domain/packageSubmission/service/PackageSubmissionCommandService.java
@@ -6,4 +6,6 @@ import circulo.server.domain.packageSubmission.dto.response.PackageSubmissionRes
 public interface PackageSubmissionCommandService {
     PackageSubmissionResponse.PackageSubmissionSuccessResponse createPackageSubmission(Long userId, Long packagingRequestId, PackageSubmissionRequest.CreatePackageSubmissionRequest request);
     PackageSubmissionResponse.PackageSubmissionAcceptedResponse acceptPackageSubmission(Long userId, Long packageSubmissionId, Long packagingRequestId);
+
+    void markAsDelivered(Long packageSubmissionId);
 }

--- a/server/src/main/java/circulo/server/domain/packageSubmission/service/PackageSubmissionCommandServiceImpl.java
+++ b/server/src/main/java/circulo/server/domain/packageSubmission/service/PackageSubmissionCommandServiceImpl.java
@@ -1,5 +1,8 @@
 package circulo.server.domain.packageSubmission.service;
 
+import circulo.server.domain.delivery.entity.Delivery;
+import circulo.server.domain.delivery.entity.enums.DeliveryStatus;
+import circulo.server.domain.delivery.repository.DeliveryRepository;
 import circulo.server.domain.packageSubmission.converter.PackageSubmissionConverter;
 import circulo.server.domain.packageSubmission.dto.request.PackageSubmissionRequest;
 import circulo.server.domain.packageSubmission.dto.response.PackageSubmissionResponse;
@@ -20,6 +23,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -28,6 +33,7 @@ public class PackageSubmissionCommandServiceImpl implements PackageSubmissionCom
     private final PackageSubmissionRepository packageSubmissionRepository;
     private final PackagingRequestRepository packagingRequestRepository;
     private final UserRepository userRepository;
+    private final DeliveryRepository deliveryRepository;
     private final PackageSubmissionConverter packageSubmissionConverter;
 
     @Override
@@ -77,4 +83,16 @@ public class PackageSubmissionCommandServiceImpl implements PackageSubmissionCom
 
         return packageSubmissionConverter.toPackageSubmissionAcceptedResponse(packageSubmission);
     }
+
+    @Override
+    public void markAsDelivered(Long packageSubmissionId) {
+        PackageSubmission packageSubmission = packageSubmissionRepository.findById(packageSubmissionId)
+                .orElseThrow(() -> new PackageSubmissionException(ErrorStatus.PACKAGE_SUBMISSION_NOT_FOUND));
+
+        packageSubmission.changeStatus(PackageSubmissionStatus.DELIVERED);
+
+        Optional<Delivery> optionalDelivery = deliveryRepository.findByPackageSubmissionId(packageSubmissionId);
+        optionalDelivery.ifPresent(delivery -> delivery.changeStatus(DeliveryStatus.DELIVERED));
+    }
+
 }


### PR DESCRIPTION
<!----제목은 [type/#IssueNumber] 작업 내용 -->
<!----ex) [setting/#1] 디자인 시스템 폰트 정의 -->

## **♻️ ISSUE**

- closed #43 

## **❗ WORK DESCRIPTION**

- 소상공인이 배달완료 버튼 누르면 해당 PackagingSubmission 배달 완료 처리 API 구현


## **📸 SCREENSHOT**

<!---- <video src="" width="300" /> -->
<!---- <img src="" width="300" /> -->
<!----Before | After
  :--: | :--:
  <img src="" width="300" /> | <img src="" width="300" >-->

## **💻 주요 코드**

- 소상공인이 배달 완료 처리 버튼 눌렀을 때, 해당 PackagingSubmission 객체의 상태를 `delivered`로 변경합니다.
- 해당 PackagingSubmissionId로 매칭되는 Delivery 객체가 있다면, 해당 객체의 상태도 `delivered`로 변경합니다.

## **📢 TO REVIEWERS**
- 수정할 부분 있다면 말씀해주세요!
